### PR TITLE
Add icon size controls and delete button

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -20,6 +20,8 @@ export const ID_CUSTOM_ICON_URL = `${EXTENSION_NAME}-custom-icon-url`;
 // --- 新增ID ---
 export const ID_CUSTOM_ICON_SIZE_INPUT = `${EXTENSION_NAME}-custom-icon-size`;
 export const ID_FA_ICON_CODE_INPUT = `${EXTENSION_NAME}-fa-icon-code`;
+export const ID_ICON_SIZE_INPUT = `${EXTENSION_NAME}-icon-size`;
+export const ID_ICON_SIZE_RESET = `${EXTENSION_NAME}-icon-size-reset`;
 // --- 结束新增 ---
 export const ID_COLOR_MATCH_CHECKBOX = `${EXTENSION_NAME}-color-match`;
 
@@ -48,6 +50,7 @@ export const ID_USAGE_PANEL = `${EXTENSION_NAME}-usage-panel`;
 
 export const ID_CUSTOM_ICON_SAVE = `${EXTENSION_NAME}-custom-icon-save`;
 export const ID_CUSTOM_ICON_SELECT = `${EXTENSION_NAME}-custom-icon-select`;
+export const ID_CUSTOM_ICON_DELETE = `${EXTENSION_NAME}-custom-icon-delete`;
 
 // --- 默认图标选项 ---
 export const ICON_TYPES = {
@@ -83,3 +86,4 @@ export const DEFAULT_MENU_STYLES = {
 
 // --- 默认图标大小 ---
 export const DEFAULT_CUSTOM_ICON_SIZE = 20;
+export const DEFAULT_ICON_SIZE = 20;

--- a/events.js
+++ b/events.js
@@ -6,7 +6,7 @@ import { updateMenuVisibilityUI } from './ui.js';
 import { triggerQuickReply, triggerJsRunnerScript } from './api.js';
 // 导入 settings.js 中的函数用于处理设置变化和UI更新
 // handleSettingsChange, handleUsageButtonClick, closeUsagePanel, updateIconDisplay 都在 settings.js 中定义和导出
-import { handleSettingsChange, handleUsageButtonClick, closeUsagePanel, updateIconDisplay } from './settings.js';
+import { handleSettingsChange, handleUsageButtonClick, closeUsagePanel, updateIconDisplay, resetIconSize } from './settings.js';
 // 导入 index.js 的设置对象 (用于样式函数)
 import { extension_settings } from './index.js'; // Assuming index.js exports extension_settings
 
@@ -473,6 +473,7 @@ export function setupEventListeners() {
     safeAddListener(Constants.ID_ICON_TYPE_DROPDOWN, 'change', handleSettingsChange);
     safeAddListener(Constants.ID_CUSTOM_ICON_URL, 'input', handleSettingsChange);
     safeAddListener(Constants.ID_CUSTOM_ICON_SIZE_INPUT, 'input', handleSettingsChange);
+    safeAddListener(Constants.ID_ICON_SIZE_INPUT, 'input', handleSettingsChange);
     safeAddListener(Constants.ID_FA_ICON_CODE_INPUT, 'input', handleSettingsChange);
     safeAddListener(Constants.ID_COLOR_MATCH_CHECKBOX, 'change', handleSettingsChange);
 
@@ -488,6 +489,7 @@ export function setupEventListeners() {
     safeAddListener(`${Constants.ID_MENU_STYLE_PANEL}-close`, 'click', closeMenuStylePanel); // from this file
     safeAddListener(`${Constants.ID_MENU_STYLE_PANEL}-apply`, 'click', applyMenuStyles); // from this file
     safeAddListener(Constants.ID_RESET_STYLE_BUTTON, 'click', resetMenuStyles); // from this file
+    safeAddListener(Constants.ID_ICON_SIZE_RESET, 'click', resetIconSize);
 
     // 不透明度滑块监听
     safeAddListener('qr-item-opacity', 'input', function(e) {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ if (!window.extension_settings[Constants.EXTENSION_NAME]) {
         iconType: Constants.ICON_TYPES.ROCKET,
         customIconUrl: '',
         customIconSize: Constants.DEFAULT_CUSTOM_ICON_SIZE,
+        iconSize: Constants.DEFAULT_ICON_SIZE,
         faIconCode: '',
         matchButtonColors: true,
         menuStyles: JSON.parse(JSON.stringify(Constants.DEFAULT_MENU_STYLES)),
@@ -88,6 +89,7 @@ function initializePlugin() {
         sharedState.domElements.globalItemsContainer = menu.querySelector(`#${Constants.ID_GLOBAL_ITEMS}`);
         sharedState.domElements.customIconUrl = document.getElementById(Constants.ID_CUSTOM_ICON_URL);
         sharedState.domElements.customIconSizeInput = document.getElementById(Constants.ID_CUSTOM_ICON_SIZE_INPUT);
+        sharedState.domElements.iconSizeInput = document.getElementById(Constants.ID_ICON_SIZE_INPUT);
         sharedState.domElements.faIconCodeInput = document.getElementById(Constants.ID_FA_ICON_CODE_INPUT);
         sharedState.domElements.colorMatchCheckbox = document.getElementById(Constants.ID_COLOR_MATCH_CHECKBOX);
 
@@ -99,7 +101,8 @@ function initializePlugin() {
                 const enabledDropdown = document.getElementById(Constants.ID_SETTINGS_ENABLED_DROPDOWN);
                 const iconTypeDropdown = document.getElementById(Constants.ID_ICON_TYPE_DROPDOWN);
                 const customIconUrlInput = document.getElementById(Constants.ID_CUSTOM_ICON_URL); // Renamed for clarity
-                const customIconSizeInput = document.getElementById(Constants.ID_CUSTOM_ICON_SIZE_INPUT);
+               const customIconSizeInput = document.getElementById(Constants.ID_CUSTOM_ICON_SIZE_INPUT);
+                const iconSizeInput = document.getElementById(Constants.ID_ICON_SIZE_INPUT);
                 const faIconCodeInput = document.getElementById(Constants.ID_FA_ICON_CODE_INPUT);
                 const colorMatchCheckbox = document.getElementById(Constants.ID_COLOR_MATCH_CHECKBOX);
 
@@ -112,6 +115,7 @@ function initializePlugin() {
                 }
 
                 if (customIconSizeInput) settings.customIconSize = parseInt(customIconSizeInput.value, 10) || Constants.DEFAULT_CUSTOM_ICON_SIZE;
+                if (iconSizeInput) settings.iconSize = parseInt(iconSizeInput.value, 10) || Constants.DEFAULT_ICON_SIZE;
                 if (faIconCodeInput) settings.faIconCode = faIconCodeInput.value;
                 if (colorMatchCheckbox) settings.matchButtonColors = colorMatchCheckbox.checked;
 
@@ -194,6 +198,7 @@ function loadAndApplyInitialSettings() {
     settings.iconType = settings.iconType || Constants.ICON_TYPES.ROCKET;
     settings.customIconUrl = settings.customIconUrl || '';
     settings.customIconSize = settings.customIconSize || Constants.DEFAULT_CUSTOM_ICON_SIZE;
+    settings.iconSize = settings.iconSize || Constants.DEFAULT_ICON_SIZE;
     settings.faIconCode = settings.faIconCode || '';
     settings.matchButtonColors = settings.matchButtonColors !== false;
     settings.menuStyles = settings.menuStyles || JSON.parse(JSON.stringify(Constants.DEFAULT_MENU_STYLES));


### PR DESCRIPTION
## Summary
- add constants for icon size controls
- add icon size support to index and settings
- allow deleting saved icons and resetting icon size
- update events listeners for new controls
- hide color match checkbox in settings UI

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683c2a1232348320b73bea5762aeb3df
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added icon size controls and a delete button for custom icons in the settings panel.

- **New Features**
  - Users can adjust icon size and reset it to default.
  - Added a button to delete saved custom icons.
  - Hid the color match checkbox in the settings UI.

<!-- End of auto-generated description by cubic. -->

